### PR TITLE
Fix warnings about deprecated mnemonics on newer builds of rgbds

### DIFF
--- a/engine/animated_objects_3e.asm
+++ b/engine/animated_objects_3e.asm
@@ -391,4 +391,4 @@ ExecuteCurrentAnimatedObjectCallback:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -240,7 +240,7 @@ PlayAnimation:
 	ld h, a
 	ld de, .nextAnimationCommand
 	push de
-	jp [hl] ; jump to special effect function
+	jp hl ; jump to special effect function
 .playSubanimation
 	ld c, a
 	and a, %00111111
@@ -481,7 +481,7 @@ PlayApplyingAttackAnimation:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 AnimationTypePointerTable:
 	dw ShakeScreenVertically ; enemy mon has used a damaging move without a side effect
@@ -690,7 +690,7 @@ DoSpecialEffectByAnimationId:
 	ld l, a
 	ld de, .done
 	push de
-	jp [hl]
+	jp hl
 .done
 	pop bc
 	pop de
@@ -1129,7 +1129,7 @@ CallWithTurnFlipped:
 	ld [H_WHOSETURN], a
 	ld de, .returnAddress
 	push de
-	jp [hl]
+	jp hl
 .returnAddress
 	pop af
 	ld [H_WHOSETURN], a

--- a/engine/battle/battle_transitions.asm
+++ b/engine/battle/battle_transitions.asm
@@ -62,7 +62,7 @@ BattleTransition:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ; the three GetBattleTransitionID functions set the first
 ; three bits of c, which determines what transition animation

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3307,7 +3307,7 @@ ExecutePlayerMove:
 	jp z, ExecutePlayerMoveDone
 	call CheckPlayerStatusConditions
 	jr nz, .playerHasNoSpecialCondition
-	jp [hl]
+	jp hl
 .playerHasNoSpecialCondition
 	call GetCurrentMove
 	ld hl, wPlayerBattleStatus1
@@ -5855,7 +5855,7 @@ ExecuteEnemyMove:
 	ld [wDamageMultipliers], a
 	call CheckEnemyStatusConditions
 	jr nz, .enemyHasNoSpecialConditions
-	jp [hl]
+	jp hl
 .enemyHasNoSpecialConditions
 	ld hl, wEnemyBattleStatus1
 	bit ChargingUp, [hl] ; is the enemy charging up for attack?
@@ -7024,7 +7024,7 @@ _JumpMoveEffect:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl] ; jump to special effect handler
+	jp hl ; jump to special effect handler
 
 MoveEffectPointerTable:
 	 dw SleepEffect               ; unused effect

--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -51,7 +51,7 @@ AIEnemyTrainerChooseMoves:
 	ld l, a
 	ld de, .nextMoveChoiceModification  ; set return address
 	push de
-	jp [hl]       ; execute modification function
+	jp hl       ; execute modification function
 .loopFindMinimumEntries ; all entries will be decremented sequentially until one of them is zero
 	ld hl, wBuffer  ; temp move selection array
 	ld de, wEnemyMonMoves  ; enemy moves
@@ -372,7 +372,7 @@ TrainerAI:
 	ld h,[hl]
 	ld l,a
 	call Random
-	jp [hl]
+	jp hl
 .done
 	and a
 	ret

--- a/engine/cable_club.asm
+++ b/engine/cable_club.asm
@@ -309,7 +309,7 @@ CallCurrentTradeCenterFunction:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 TradeCenter_SelectMon:
 	call ClearScreen

--- a/engine/items/items.asm
+++ b/engine/items/items.asm
@@ -13,7 +13,7 @@ UseItem_:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 ItemUsePtrTable:
 	dw ItemUseBall       ; MASTER_BALL

--- a/engine/menu/start_sub_menus.asm
+++ b/engine/menu/start_sub_menus.asm
@@ -118,7 +118,7 @@ StartMenu_Pokemon:
 	ld h,[hl]
 	ld l,a
 	ld a,[wObtainedBadges] ; badges obtained
-	jp [hl]
+	jp hl
 .outOfBattleMovePointers
 	dw .cut
 	dw .fly

--- a/engine/menu/text_ids2.asm
+++ b/engine/menu/text_ids2.asm
@@ -24,7 +24,7 @@ DisplayTextBoxID_:
 	ld l,a ; hl = address of function
 	ld de,.done
 	push de
-	jp [hl] ; jump to the function
+	jp hl ; jump to the function
 .coordTableMatch
 	call GetTextBoxIDCoords
 	call GetAddressOfScreenCoords

--- a/engine/overworld/check_player_state.asm
+++ b/engine/overworld/check_player_state.asm
@@ -105,7 +105,7 @@ IsPlayerFacingEdgeOfMap:
 	ld c, a
 	ld de, .returnaddress
 	push de
-	jp [hl]
+	jp hl
 .returnaddress
 	pop bc
 	pop de

--- a/engine/overworld/ssanne.asm
+++ b/engine/overworld/ssanne.asm
@@ -17,7 +17,7 @@ AnimateBoulderDust:
 	ld bc, .returnAddress
 	push bc
 	ld c, 4
-	jp [hl]
+	jp hl
 .returnAddress
 	ld a, [rOBP1]
 	xor %01100100

--- a/engine/palettes.asm
+++ b/engine/palettes.asm
@@ -17,7 +17,7 @@ _RunPaletteCommand:
 	ld l, a
 	ld de, SendSGBPackets
 	push de
-	jp [hl]
+	jp hl
 
 SetPal_Black:
 	ld hl, PalPacket_Black

--- a/engine/pikachu_movement.asm
+++ b/engine/pikachu_movement.asm
@@ -121,7 +121,7 @@ ExecutePikachuMovementCommand:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 GetCoordsForPikachuShadow:
 	ld hl, wPlayerSpriteImageIdx - wPlayerSpriteStateData1
@@ -487,7 +487,7 @@ UpdatePikachuPosition:
 	ld l, a
 	pop de
 	ld a, d
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw .Down

--- a/engine/printer/serial.asm
+++ b/engine/printer/serial.asm
@@ -28,7 +28,7 @@ PrinterTransmissionJumptable:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw Printer_InitSerial ; 00
@@ -448,7 +448,7 @@ PrinterSerial_:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw .Nop

--- a/engine/slot_machine.asm
+++ b/engine/slot_machine.asm
@@ -452,7 +452,7 @@ SlotMachine_CheckForMatches:
 	pop hl
 	ld de, .flashScreenLoop
 	push de
-	jp [hl]
+	jp hl
 
 .flashScreenLoop
 	ld a, [rBGP]

--- a/engine/surfing_minigame.asm
+++ b/engine/surfing_minigame.asm
@@ -384,7 +384,7 @@ RunSurfingMinigameRoutine:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw SurfingMinigameRoutine_SpawnPikachu ; 0
@@ -672,7 +672,7 @@ SurfingMinigameAnimatedObjectFn_Pikachu
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 Jumptable_f847f:
 	dw Func_f848d
@@ -1976,7 +1976,7 @@ SurfingMinigame_GetWaveDataPointers:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 Jumptable_f8d53:
 	dw SurfingMinigameWaveFunction_NoWave ; 00

--- a/engine/titlescreen.asm
+++ b/engine/titlescreen.asm
@@ -266,7 +266,7 @@ DoTitleScreenFunction:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 	
 .Jumptable:

--- a/engine/trade.asm
+++ b/engine/trade.asm
@@ -47,7 +47,7 @@ TradeAnimCommon:
 	ld l, a
 	ld de, .loop
 	push de
-	jp [hl] ; call trade func, which will return to the top of the loop
+	jp hl ; call trade func, which will return to the top of the loop
 .done
 	pop af
 	ld [hSCX], a

--- a/engine/unknown_ea3ea.asm
+++ b/engine/unknown_ea3ea.asm
@@ -240,7 +240,7 @@ PrinterDebug_DoFunction:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw Func_ea623
@@ -705,7 +705,7 @@ PrinterDebug_PrepOAMForPrinting:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .Jumptable:
 	dw .nop
@@ -823,7 +823,7 @@ PrinterDebug_PrepOAMForPrinting:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .PalJumptable:
 	dw .Pal0
@@ -865,7 +865,7 @@ PrinterDebug_PrepOAMForPrinting:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 .PalFunJumptable:
 	dw .zero_zero

--- a/engine/yellow_intro.asm
+++ b/engine/yellow_intro.asm
@@ -98,7 +98,7 @@ Func_f98fc:
 	ld a, [wYellowIntroCurrentScene]
 	ld hl, Jumptable_f9906
 	call Func_fa06e
-	jp [hl]
+	jp hl
 
 Jumptable_f9906:
 	dw YellowIntroScene0 ; running pika 1
@@ -985,7 +985,7 @@ Func_fa02b:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	jp [hl]
+	jp hl
 
 Jumptable_fa03b:
 	dw Func_fa03f

--- a/home.asm
+++ b/home.asm
@@ -4592,7 +4592,7 @@ JumpTable::
 	ld l, a
 	ld de, .returnAddress
 	push de
-	jp [hl]
+	jp hl
 .returnAddress
 	pop bc
 	pop de
@@ -4776,7 +4776,7 @@ Bankswitch::
 	ld [MBC1RomBank], a
 	ret
 JumpToAddress::
-	jp [hl]
+	jp hl
 
 SwitchSRAMBankAndLatchClockData::
 	push af

--- a/home/overworld.asm
+++ b/home/overworld.asm
@@ -1761,7 +1761,7 @@ RunMapScript::
 	ld l, a
 	ld de, .return
 	push de
-	jp [hl] ; jump to script
+	jp hl ; jump to script
 .return
 	ret
 

--- a/home/predef.asm
+++ b/home/predef.asm
@@ -23,7 +23,7 @@ Predef::
 
 	ld de, .done
 	push de
-	jp [hl]
+	jp hl
 .done
 
 	pop af


### PR DESCRIPTION
This fixes warnings about deprecated mnemonics, specifically `'JP [HL]' is obsolete, use 'JP HL' instead.`.

Building with newer versions of RGBDS doesn't actually work; there are other issues.  However this is a quick change that works in both versions, so I'm making this PR now while I try to figure out the other problems.