### PR TITLE
Update code for rgbds 0.3.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,9 @@ $(objs): %.o: %.asm $$(%_dep)
 opts = -cjsv -k 01 -l 0x33 -m 0x1b -p 0 -r 03 -t "POKEMON YELLOW"
 
 $(rom): $(objs)
-	rgblink -n $*.sym -o $@ $^
+	rgblink -n $*.sym -l linkerscript.link -o $@ $^
 	rgbfix $(opts) $@
+	sort $(rom:.gbc=.sym) -o $(rom:.gbc=.sym)
 
 %.png:  ;
 %.2bpp: %.png  ; @$(2bpp) $<

--- a/linkerscript.link
+++ b/linkerscript.link
@@ -1,0 +1,236 @@
+ROM0
+  ORG $61
+  "Home"
+  ORG $150
+  "Main"
+
+ROMX $1
+  "bank01"
+
+ROMX $2
+  "Sound Effect Headers 1" ; AUDIO_1
+  "Music Headers 1"
+  "Sound Effects 1"
+  "Audio Engine 1"
+  "Music 1"
+
+ROMX $3
+  "bank03"
+
+ROMX $4
+  "Graphics"
+  "NPC Sprites 1"
+
+ROMX $5
+  "NPC Sprites 2"
+
+ROMX $6
+  "bank06"
+
+ROMX $7
+  "bank07"
+
+ROMX $8
+  "Sound Effect Headers 2" ; AUDIO_2
+  "Music Headers 2"
+  "Sound Effects 2"
+  "Audio Engine 2"
+  "Music 2"
+
+ROMX $9
+  "Pics 1"
+
+ROMX $A
+  "Pics 2"
+
+ROMX $B
+  "Pics 3"
+
+ROMX $C
+  "Pics 4"
+
+ROMX $D
+  "Pics 5"
+
+ROMX $E
+  "bank0E"
+
+ROMX $F
+  "bank0F"
+
+ROMX $10
+  "bank10"
+
+ROMX $11
+  "bank11"
+
+ROMX $12
+  "bank12"
+
+ROMX $13
+  "bank13"
+
+ROMX $14
+  "bank14"
+
+ROMX $15
+  "bank15"
+
+ROMX $16
+  "bank16"
+
+ROMX $17
+  "bank17"
+
+ROMX $18
+  "bank18"
+
+ROMX $19
+  "bank19"
+
+ROMX $1A
+  "bank1A"
+
+ROMX $1B
+  "bank1B"
+
+ROMX $1C
+  "bank1C"
+
+ROMX $1D
+  "bank1D"
+
+ROMX $1E
+  "bank1E"
+
+ROMX $1F
+  "Sound Effect Headers 3" ; AUDIO_3
+  "Music Headers 3"
+  "Sound Effects 3"
+  "Audio Engine 3"
+  "Music 3"
+
+ROMX $20
+  "Sound Effect Headers 4" ; AUDIO_3
+  "Music Headers 4"
+  "Sound Effects 4"
+  "Audio Engine 4"
+  "Music 4"
+
+ROMX $21
+  "Pikachu Cries 1"
+
+ROMX $22
+  "Pikachu Cries 2"
+
+ROMX $23
+  "Pikachu Cries 3"
+
+ROMX $24
+  "Pikachu Cries 4"
+
+ROMX $25
+  "Pikachu Cries 5"
+
+ROMX $26
+  "Text 1"
+
+ROMX $27
+  "Text 2"
+
+ROMX $28
+  "Text 3"
+
+ROMX $29
+  "Text 4"
+
+ROMX $2A
+  "Text 5"
+
+ROMX $2B
+  "Text 6"
+
+ROMX $2C
+  "Text 7"
+
+ROMX $2D
+  "Text 8"
+
+ROMX $2E
+  "Pokedex Text"
+
+ROMX $2f
+  "Move Names"
+;  "bank2f"
+
+ROMX $30
+  "bank30"
+
+ROMX $31
+  "Pikachu Cries 6"
+
+ROMX $32
+  "Pikachu Cries 7"
+
+ROMX $33
+  "Pikachu Cries 8"
+
+ROMX $34
+  "Pikachu Cries 9"
+
+ROMX $35
+  "Pikachu Cries 10"
+
+ROMX $36
+  "Pikachu Cries 11"
+
+ROMX $37
+  "Pikachu Cries 12"
+
+ROMX $38
+  "Pikachu Cries 13"
+
+ROMX $39
+  "bank39"
+
+ROMX $3A
+  "bank3A"
+
+; ROMX $3B
+;   "bank3B"
+
+ROMX $3C
+  "bank3C"
+
+ROMX $3D
+  "bank3D"
+
+ROMX $3E
+  "bank3E"
+
+ROMX $3F
+  "bank3F"
+
+WRAM0
+  "WRAM Bank 0"
+
+WRAMX 1
+  "WRAM Bank 1"
+;  ORG $df00
+;  "Stack"
+
+; WRAMX 5
+;   "WRAMBank5"
+
+SRAM 0
+  "Sprite Buffers"
+
+SRAM 1
+  "Save Data"
+
+SRAM 2
+  "Saved Boxes 1"
+
+SRAM 3
+  "Saved Boxes 2"
+

--- a/wram.asm
+++ b/wram.asm
@@ -514,6 +514,8 @@ wc6ed:: ; c6ed
 wPrinterChecksum:: ; c6ee
 	dw
 
+UNION
+
 wPrinterSerialReceived:: ; c6f0
 	ds 1
 wPrinterStatusReceived:: ; c6f1
@@ -533,13 +535,16 @@ wLYOverridesEnd::
 wLYOverridesBuffer:: ; c800
 	ds $100
 wLYOverridesBufferEnd:: ; c900
-	ds wPrinterSerialReceived - @
+
+NEXTU
 
 wPrinterSendDataSource1:: ; c6f0
 ; two 20-tile buffers
 	ds $140
 wPrinterSendDataSource2::
 	ds $140
+ENDU
+
 wPrinterSendDataSource1End:: ; c970
 
 wPrinterHandshake:: ; c970
@@ -2849,6 +2854,8 @@ wPikachuMovementFlags:: ; d44c
 ; bit 7 - signal end of command
 	ds 1
 
+UNION
+
 wCurPikaMovementData:: ; d44d
 wCurPikaMovementParam1:: ds 1 ; d44d
 wCurPikaMovementFunc1:: ds 1 ; d44e
@@ -2864,8 +2871,8 @@ wPikachuStepTimer:: ds 1 ; d457
 wPikachuStepSubtimer:: ds 1 ; d458
 	ds 5
 wCurPikaMovementDataEnd:: ; d45e
-	ds wCurPikaMovementData - @
 
+NEXTU
 
 wPikaPicAnimPointer:: dw ; d44d
 wPikaPicAnimPointerSetupFinished:: ds 1 ; d44f
@@ -2886,6 +2893,7 @@ wCurPikaPicAnimObjectFrameTimer:: db ; d45b
 wCurPikaPicAnimObjectEnd:: ; d45d
 
 	ds 18
+ENDU
 
 wPikachuHappiness:: ds 1 ; d46f
 wPikachuMood:: ds 1 ; d470
@@ -3493,10 +3501,12 @@ wSerialEnemyDataBlock:: ; d892
 wEnemyPartyCount:: ds 1     ; d89b
 wEnemyPartyMons::  ds PARTY_LENGTH + 1 ; d89c
 
+UNION
+
 wWaterRate:: db ; d8a3
 wWaterMons:: db ; d8a4
 
-	ds wWaterRate - @
+NEXTU
 
 wEnemyMons:: ; d8a3
 wEnemyMon1:: party_struct wEnemyMon1
@@ -3509,6 +3519,7 @@ wEnemyMon6:: party_struct wEnemyMon6
 wEnemyMonOT::    ds NAME_LENGTH * PARTY_LENGTH ; d9ab
 wEnemyMonNicks:: ds NAME_LENGTH * PARTY_LENGTH ; d9ed
 
+ENDU
 
 wTrainerHeaderPtr:: ; da2f
 	ds 2

--- a/wram.asm
+++ b/wram.asm
@@ -3593,9 +3593,9 @@ wLastOBP1:: ds 1 ; def3
 wdef5:: ds 1 ; def4
 wBGPPalsBuffer:: ds NUM_ACTIVE_PALS * PAL_SIZE ; def5
 
-SECTION "Stack", WRAMX[$dfff], BANK[1]
+SECTION "Stack", WRAMX[$df15], BANK[1]
+	ds $ea
 wStack:: ; dfff
-	ds -$100
 
 
 INCLUDE "sram.asm"


### PR DESCRIPTION
This PR updates the code for RGBDS 0.3.3.  RGBDS 0.2.5 is no longer supported.

I should note that I have no idea what I'm doing.  This linkerscript may not be correct (and I'm not sure if `linkerscript.link` is the best name - pret/pokecrystal#389 uses `linkerscript.ld`, but the others use `linkerscript.link`).  I haven't removed existing bank definitions from the files themselves, and there are some section definitions that aren't in the linkerscript.

However, the rom hash matches, and the symbol list matches that from before this change.  So I think everything works.

The change that I really don't know for sure, though, is my change to the stack.  Originally, it looked like this (bottom of wram.asm):

```asm
wGBCBasePalPointers:: ds NUM_ACTIVE_PALS * 2 ; dee1
wGBCPal:: ds PAL_SIZE ; dee9
wLastBGP:: ds 1 ; def1
wLastOBP0:: ds 1 ; def2
wLastOBP1:: ds 1 ; def3
wdef5:: ds 1 ; def4
wBGPPalsBuffer:: ds NUM_ACTIVE_PALS * PAL_SIZE ; def5

SECTION "Stack", WRAMX[$dfff], BANK[1]
wStack:: ; dfff
	ds -$100
```

However, `ds -$100` is no longer legal, so I tried changing it to this, based off of what is done in pokered:

```asm
wGBCBasePalPointers:: ds NUM_ACTIVE_PALS * 2 ; dee1
wGBCPal:: ds PAL_SIZE ; dee9
wLastBGP:: ds 1 ; def1
wLastOBP0:: ds 1 ; def2
wLastOBP1:: ds 1 ; def3
wdef5:: ds 1 ; def4
wBGPPalsBuffer:: ds NUM_ACTIVE_PALS * PAL_SIZE ; def5

SECTION "Stack", WRAMX[$df00], BANK[1]
	ds $ff
wStack:: ; dfff
```

However, that _also_ doesn't work:

> ```
> error: Unable to place 'Stack' (WRAMX section) at $DF00 in bank $201
> make: *** [pokeyellow.gbc] Error 1
> ```

As far as I can tell, this is because `wBGPPalsBuffer` extends into $DF00 (`$def5+NUM_ACTIVE_PALS * PAL_SIZE`=`$df15`).  This seems to me like a problem, but it's the way the code was written, and as far as I can tell, it's how it's actually used (but I'm not good with assembly).  As far as I can tell this means that that buffer will clobber the stack.

I've changed the code to this:

```asm
wGBCBasePalPointers:: ds NUM_ACTIVE_PALS * 2 ; dee1
wGBCPal:: ds PAL_SIZE ; dee9
wLastBGP:: ds 1 ; def1
wLastOBP0:: ds 1 ; def2
wLastOBP1:: ds 1 ; def3
wdef5:: ds 1 ; def4
wBGPPalsBuffer:: ds NUM_ACTIVE_PALS * PAL_SIZE ; def5

SECTION "Stack", WRAMX[$df15], BANK[1]
	ds $ea
wStack:: ; dfff
```

which works fine (everything still compiles and the roms match) but I'm not entirely confident that it's correct.

See also:
* pret/pokered#147
* pret/pokecrystal#389 (pret/pokecrystal#360)