### PR TITLE
Update RGBDS repo link

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ To build on Windows, use [**Cygwin**](http://cygwin.com/install.html). Use the d
 
 In the installer, select the following packages: `make` `git` `python` `gettext`
 
-Then get the most recent version of [**rgbds**](https://github.com/bentley/rgbds/releases/).
+Then get the most recent version of [**rgbds**](https://github.com/rednex/rgbds/releases/).
 Extract the archive and put `rgbasm.exe`, `rgblink.exe` and `rgbfix.exe` in `C:\cygwin\usr\local\bin`.
 
 In the **Cygwin terminal**:


### PR DESCRIPTION
The current link redirects to rednex/rgbds, which is the currently updated repo. This removes the redirection, which might break eventually.