### PR TITLE
Rename mangled labels for OptionsMenu_TextSpeed

### DIFF
--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -51,9 +51,9 @@ OptionsMenu_TextSpeed:
 .pressedRight
 	ld a, c
 	cp $2
-	jr c, .asm_41cca
+	jr c, .Increase
 	ld c, $ff
-.asm_41cca
+.Increase
 	inc c
 	ld a, e
 	jr .Save

--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -56,7 +56,7 @@ OptionsMenu_TextSpeed:
 .asm_41cca
 	inc c
 	ld a, e
-	jr .asm_41cd6
+	jr .Save
 .pressedLeft
 	ld a, c
 	and a
@@ -65,7 +65,7 @@ OptionsMenu_TextSpeed:
 .asm_41cd4
 	dec c
 	ld a, d
-.asm_41cd6
+.Save
 	ld b, a
 	ld a, [wOptions]
 	and $f0

--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -47,31 +47,31 @@ OptionsMenu_TextSpeed:
 	jr nz, .pressedRight
 	bit 5, a
 	jr nz, .pressedLeft
-	jr .NonePressed
+	jr .nonePressed
 .pressedRight
 	ld a, c
 	cp $2
-	jr c, .Increase
+	jr c, .increase
 	ld c, $ff
-.Increase
+.increase
 	inc c
 	ld a, e
-	jr .Save
+	jr .save
 .pressedLeft
 	ld a, c
 	and a
-	jr nz, .Decrease
+	jr nz, .decrease
 	ld c, $3
-.Decrease
+.decrease
 	dec c
 	ld a, d
-.Save
+.save
 	ld b, a
 	ld a, [wOptions]
 	and $f0
 	or b
 	ld [wOptions], a
-.NonePressed
+.nonePressed
 	ld b, $0
 	ld hl, TextSpeedStringsPointerTable
 	add hl, bc

--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -60,9 +60,9 @@ OptionsMenu_TextSpeed:
 .pressedLeft
 	ld a, c
 	and a
-	jr nz, .asm_41cd4
+	jr nz, .Decrease
 	ld c, $3
-.asm_41cd4
+.Decrease
 	dec c
 	ld a, d
 .Save

--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -47,7 +47,7 @@ OptionsMenu_TextSpeed:
 	jr nz, .pressedRight
 	bit 5, a
 	jr nz, .pressedLeft
-	jr .asm_41ce0
+	jr .NonePressed
 .pressedRight
 	ld a, c
 	cp $2
@@ -71,7 +71,7 @@ OptionsMenu_TextSpeed:
 	and $f0
 	or b
 	ld [wOptions], a
-.asm_41ce0
+.NonePressed
 	ld b, $0
 	ld hl, TextSpeedStringsPointerTable
 	add hl, bc


### PR DESCRIPTION
These renames are based on https://github.com/pret/pokecrystal/blob/645719e99bd0a1d23c8035c6c6b0d3810c83e222/engine/menus/options_menu.asm#L112-L157