### PR TITLE
Improved Virtual Console patch identifiers

### DIFF
--- a/data/text/text_8.asm
+++ b/data/text/text_8.asm
@@ -3,7 +3,7 @@ _CableClubNPCPleaseWaitText::
 	text_end
 
 _CableClubNPCLinkClosedBecauseOfInactivityText::
-	vc_patch Change_MSG
+	vc_patch Change_link_closed_inactivity_message
 IF DEF(_YELLOW_VC)
 	text "Please come again!"
 	done

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -203,9 +203,9 @@ PlayAnimation:
 	ld h, [hl]
 	ld l, a
 .animationLoop
-	vc_hook FPA_005_End
+	vc_hook Stop_reducing_move_anim_flashing_Bubblebeam
 	ld a, [hli]
-	vc_hook FPA_001_End
+	vc_hook Stop_reducing_move_anim_flashing_Mega_Punch
 	cp -1
 	jr z, .AnimationOver
 	cp FIRST_SE_ID ; is this subanimation or a special effect?
@@ -279,17 +279,17 @@ PlayAnimation:
 	call LoadSubanimation
 	call PlaySubanimation
 	pop af
-	vc_hook FPA_007_End
+	vc_hook Stop_reducing_move_anim_flashing_Thunderbolt
 	ldh [rOBP0], a
-	vc_hook FPA_011_End
+	vc_hook Stop_reducing_move_anim_flashing_Explosion
 	call UpdateGBCPal_OBP0
 .nextAnimationCommand
-	vc_hook FPA_002_End
+	vc_hook Stop_reducing_move_anim_flashing_Guillotine
 	pop hl
-	vc_hook FPA_003_End
+	vc_hook Stop_reducing_move_anim_flashing_Mega_Kick
 	jr .animationLoop
 .AnimationOver
-	vc_hook FPA_004_End
+	vc_hook Stop_reducing_move_anim_flashing_Blizzard
 	ret
 
 LoadSubanimation:
@@ -301,26 +301,26 @@ LoadSubanimation:
 	ld e, a
 	ld a, [hl]
 	ld d, a ; de = address of subanimation
-	vc_hook FPA_005_Begin
+	vc_hook Reduce_move_anim_flashing_Bubblebeam
 	ld a, [de]
-	vc_hook FPA_003_Begin
+	vc_hook Reduce_move_anim_flashing_Mega_Kick
 	ld b, a
-	vc_hook FPA_002_Begin
+	vc_hook Reduce_move_anim_flashing_Guillotine
 	and %00011111
-	vc_hook FPA_001_Begin
+	vc_hook Reduce_move_anim_flashing_Mega_Punch_Explosion_Self_Destruct
 	ld [wSubAnimCounter], a ; number of frame blocks
-	vc_hook FPA_004_Begin
+	vc_hook Reduce_move_anim_flashing_Blizzard
 	ld a, b
-	vc_hook FPA_007_Begin
+	vc_hook Reduce_move_anim_flashing_Thunderbolt
 	and %11100000
 	cp SUBANIMTYPE_ENEMY << 5
-	vc_hook FPA_009_Begin
+	vc_hook Reduce_move_anim_flashing_Reflect
 	jr nz, .isNotType5
 .isType5
 	call GetSubanimationTransform2
 	jr .saveTransformation
 .isNotType5
-	vc_hook FPA_010_Begin
+	vc_hook Reduce_move_anim_flashing_Self_Destruct
 	call GetSubanimationTransform1
 .saveTransformation
 ; place the upper 3 bits of a into bits 0-2 of a before storing
@@ -351,7 +351,7 @@ LoadSubanimation:
 ; sets the transform to SUBANIMTYPE_NORMAL if it's the player's turn
 ; sets the transform to the subanimation type if it's the enemy's turn
 GetSubanimationTransform1:
-	vc_hook FPA_011_Begin
+	vc_hook Reduce_move_anim_flashing_Explosion
 	ld b, a
 	ldh a, [hWhoseTurn]
 	and a
@@ -444,12 +444,12 @@ MoveAnimation:
 	ld c, 30
 	call DelayFrames
 .next4
-	vc_hook FPA_009_End
+	vc_hook Stop_reducing_move_anim_flashing_Reflect
 	call PlayApplyingAttackAnimation ; shake the screen or flash the pic in and out (to show damage)
 .animationFinished
 	call WaitForSoundToFinish
 	xor a
-	vc_hook FPA_008_End
+	vc_hook Stop_reducing_move_anim_flashing_Haze_Hyper_Beam
 	ld [wSubAnimSubEntryAddr], a
 	ld [wUnusedD09B], a
 	ld [wSubAnimTransform], a
@@ -487,7 +487,7 @@ ShareMoveAnimations:
 PlayApplyingAttackAnimation:
 ; Generic animation that shows after the move's individual animation
 ; Different animation depending on whether the move has an additional effect and on whose turn it is
-	vc_hook FPA_010_End
+	vc_hook Stop_reducing_move_anim_flashing_Self_Destruct
 	ld a, [wAnimationType]
 	and a
 	ret z
@@ -577,10 +577,10 @@ SetAnimationPalette:
 	ld b, $f0
 .next
 	ld a, b
-	vc_hook FPA_006_Begin
+	vc_hook Reduce_move_anim_flashing_Hyper_Beam
 	ldh [rOBP0], a
 	ld a, $6c
-	vc_hook FPA_008_Begin
+	vc_hook Reduce_move_anim_flashing_Haze
 	ldh [rOBP1], a
 	call UpdateGBCPal_OBP0
 	call UpdateGBCPal_OBP1

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3192,7 +3192,7 @@ LinkBattleExchangeData:
 	ld a, b
 .doExchange
 	ld [wSerialExchangeNybbleSendData], a
-	vc_hook send_byt2
+	vc_hook Wireless_start_exchange
 	callfar PrintWaitingText
 .syncLoop1
 	call Serial_ExchangeNybble
@@ -3200,8 +3200,8 @@ LinkBattleExchangeData:
 	ld a, [wSerialExchangeNybbleReceiveData]
 	inc a
 	jr z, .syncLoop1
-	vc_hook send_byt2_ret
-	vc_patch FIGHT
+	vc_hook Wireless_end_exchange
+	vc_patch Wireless_net_delay_1
 IF DEF(_YELLOW_VC)
 	ld b, 26
 ELSE
@@ -3213,8 +3213,8 @@ ENDC
 	call Serial_ExchangeNybble
 	dec b
 	jr nz, .syncLoop2
-	vc_hook send_dummy
-	vc_patch FIGHT2
+	vc_hook Wireless_start_send_zero_bytes
+	vc_patch Wireless_net_delay_2
 IF DEF(_YELLOW_VC)
 	ld b, 26
 ELSE
@@ -3226,7 +3226,7 @@ ENDC
 	call Serial_SendZeroByte
 	dec b
 	jr nz, .syncLoop3
-	vc_hook send_dummy_end
+	vc_hook Wireless_end_send_zero_bytes
 	ret
 
 ExecutePlayerMove:
@@ -6860,8 +6860,8 @@ BattleRandom:
 	ld a, [hl]
 	pop bc
 	pop hl
-	vc_hook fight_ret_c
-	vc_patch fight_ret
+	vc_hook Unknown_BattleRandom_ret_c
+	vc_patch BattleRandom_ret
 IF DEF(_YELLOW_VC)
 	ret
 ELSE

--- a/engine/gfx/palettes.asm
+++ b/engine/gfx/palettes.asm
@@ -657,7 +657,7 @@ CheckSGB:
 SendMltReq1Packet:
 	ld hl, MltReq1Packet
 	call SendSGBPacket
-	vc_hook Network_RESET
+	vc_hook Unknown_network_reset
 	jp Wait7000
 
 CopyGfxToSuperNintendoVRAM:

--- a/engine/link/cable_club.asm
+++ b/engine/link/cable_club.asm
@@ -130,14 +130,14 @@ CableClub_DoBattleOrTradeAgain:
 	ld hl, wSerialPlayerDataBlock
 	ld de, wSerialEnemyDataBlock
 	ld bc, $1a8
-	vc_hook Network424
+	vc_hook Wireless_ExchangeBytes_1
 	call Serial_ExchangeBytes
 	ld a, SERIAL_NO_DATA_BYTE
 	ld [de], a
 	ld hl, wSerialPartyMonsPatchList
 	ld de, wSerialEnemyMonsPatchList
 	ld bc, $c8
-	vc_hook Network200
+	vc_hook Wireless_ExchangeBytes_2
 	call Serial_ExchangeBytes
 	ld a, (1 << SERIAL) | (1 << TIMER) | (1 << VBLANK)
 	ldh [rIE], a
@@ -868,7 +868,7 @@ TradeCenter_Trade:
 	ld de, TradeCompleted
 	call PlaceString
 	predef SaveSAVtoSRAM2
-	vc_hook save_game_end
+	vc_hook Trade_save_game_end
 	ld c, 50
 	call DelayFrames
 	xor a

--- a/engine/link/cable_club_npc.asm
+++ b/engine/link/cable_club_npc.asm
@@ -34,7 +34,7 @@ CableClubNPC::
 ; USING_INTERNAL_CLOCK, which allows the player to proceed past the link
 ; receptionist's "Please wait." It assumes that hSerialConnectionStatus is at
 ; its original address.
-	vc_hook linkCable_fake_begin
+	vc_hook Link_fake_connection_status
 	vc_assert hSerialConnectionStatus == $ffaa, \
 		"hSerialConnectionStatus is no longer located at 00:ffaa"
 	vc_assert USING_INTERNAL_CLOCK == $02, \
@@ -66,7 +66,7 @@ CableClubNPC::
 	ld a, [wCurrentMenuItem]
 	and a
 	jr nz, .choseNo
-	vc_hook linkCable_block_input
+	vc_hook Wireless_TryQuickSave_block_input
 	callfar SaveSAVtoSRAM
 	call WaitForSoundToFinish
 	ld a, SFX_SAVE
@@ -80,9 +80,9 @@ CableClubNPC::
 	ld [hl], a
 	ldh [hSerialReceivedNewData], a
 	ld [wSerialExchangeNybbleSendData], a
-	vc_hook linkCable_fake_end
+	vc_hook Wireless_prompt
 	call Serial_SyncAndExchangeNybble
-	vc_hook Network_RECHECK
+	vc_hook Wireless_net_recheck
 	ld hl, wUnknownSerialCounter
 	ld a, [hli]
 	inc a

--- a/engine/menus/link_menu.asm
+++ b/engine/menus/link_menu.asm
@@ -794,11 +794,11 @@ LinkMenu:
 	call Delay3
 	callfar CloseLinkConnection
 	ld hl, ColosseumCanceledText
-	vc_hook Network_STOP
+	vc_hook Wireless_net_stop
 	call PrintText
 	ld hl, wd72e
 	res 6, [hl]
-	vc_hook Network_END
+	vc_hook Wireless_net_end
 	ret
 
 .asm_f5963

--- a/engine/menus/pokedex.asm
+++ b/engine/menus/pokedex.asm
@@ -111,7 +111,7 @@ HandlePokedexSideMenu:
 	dec a
 	jr z, .choseArea
 	dec a
-	vc_patch disable_print
+	vc_patch Forbid_printing_Pokedex
 IF DEF (_YELLOW_VC)
 	jr z, .handleMenuInput
 ELSE

--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -37,7 +37,7 @@ LoadSAV0:
 	ld [MBC1SRamBank], a
 ; This vc_hook does not have to be in any particular location.
 ; It is defined here because it refers to the same labels as the two lines below.
-	vc_hook SaveLimit
+	vc_hook Unknown_save_limit
 	ld hl, sGameData
 	ld bc, sGameDataEnd - sGameData
 	call SAVCheckSum

--- a/engine/movie/intro_yellow.asm
+++ b/engine/movie/intro_yellow.asm
@@ -30,7 +30,7 @@ PlayIntroScene:
 	jr .loop
 
 .go_to_title_screen
-	vc_hook FPA_031801_End3
+	vc_hook Stop_Reducing_intro_scene_flashing
 	call YellowIntro_BlankPalettes
 	xor a
 	ldh [hLCDCPointer], a
@@ -124,7 +124,7 @@ Jumptable_f9906:
 YellowIntro_NextScene:
 	ld hl, wYellowIntroCurrentScene
 	inc [hl]
-	vc_hook FPA_031801_Begin1
+	vc_hook Reduce_intro_scene_flashing_0E
 	ret
 
 YellowIntroScene0:
@@ -603,7 +603,7 @@ YellowIntroScene14:
 	call YellowIntro_SpawnAnimatedObjectAndSavePointer
 	call YellowIntro_NextScene
 	ld a, $28
-	vc_hook FPA_031801_Begin2
+	vc_hook Reduce_intro_scene_flashing_0F
 	ld [wYellowIntroSceneTimer], a
 	ret
 
@@ -708,14 +708,14 @@ YellowIntro_CheckFrameTimerDecrement:
 	ret
 
 .asm_f9e4b
-	vc_hook FPA_031801_End2
+	vc_hook Stop_reducing_intro_scene_flashing_0F
 	scf
 	ret
 
 YellowIntro_LoadDMGPalAndIncrementCounter:
 	ld hl, wYellowIntroSceneTimer
 	ld a, [hl]
-	vc_hook FPA_031801_End1
+	vc_hook Stop_reducing_intro_scene_flashing_0E
 	inc [hl]
 	ld l, a
 	ld h, $0

--- a/engine/pikachu/pikachu_pcm.asm
+++ b/engine/pikachu/pikachu_pcm.asm
@@ -1,5 +1,5 @@
 PlayPikachuSoundClip::
-	vc_hook PLAY_NEW
+	vc_hook Unknown_PlayPikachuSoundClip_start
 	ld a, e
 	ld e, a
 	ld d, $0
@@ -40,7 +40,7 @@ PlayPikachuSoundClip::
 	ld a, l
 	cp $40 ; end of wave data
 	jr nz, .saveWaveDataLoop
-	vc_patch PLAY_MUTE
+	vc_patch Unknown_PlayPikachuSoundClip_end
 IF DEF(_YELLOW_VC)
 	ld a, 0
 ELSE

--- a/home/pikachu_cries.asm
+++ b/home/pikachu_cries.asm
@@ -1,5 +1,5 @@
 PlayPikachuPCM::
-	vc_hook PLAY_HACK
+	vc_hook Unknown_PlayPikachuPCM
 	ldh a, [hLoadedROMBank]
 	push af
 	ld a, b

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -233,7 +233,7 @@ Serial_PrintWaitingTextAndSyncAndExchangeNybble::
 	jp LoadScreenTilesFromBuffer1
 
 Serial_SyncAndExchangeNybble::
-	vc_hook send_send_buf2
+	vc_hook Wireless_WaitLinkTransfer
 	ld a, $ff
 	ld [wSerialExchangeNybbleReceiveData], a
 .loop1
@@ -257,7 +257,7 @@ Serial_SyncAndExchangeNybble::
 	ld a, [wSerialExchangeNybbleReceiveData]
 	inc a
 	jr z, .loop1
-	vc_patch Network10
+	vc_patch Wireless_net_delay_3
 IF DEF(_YELLOW_VC)
 	ld b, 26
 ELSE
@@ -269,7 +269,7 @@ ENDC
 	call Serial_ExchangeNybble
 	dec b
 	jr nz, .loop2
-	vc_patch Network11
+	vc_patch Wireless_net_delay_4
 IF DEF(_YELLOW_VC)
 	ld b, 26
 ELSE
@@ -283,7 +283,7 @@ ENDC
 	jr nz, .loop3
 	ld a, [wSerialExchangeNybbleReceiveData]
 	ld [wSerialSyncAndExchangeNybbleReceiveData], a
-	vc_hook send_send_buf2_ret
+	vc_hook Wireless_WaitLinkTransfer_ret
 	ret
 
 Serial_ExchangeNybble::

--- a/scripts/SummerBeachHouse.asm
+++ b/scripts/SummerBeachHouse.asm
@@ -13,7 +13,7 @@ SummerBeachHouse_TextPointers:
 SurfinDudeText:
 	text_asm
 	ld a, [wd472]
-	vc_patch MiniGame
+	vc_patch Bypass_need_Pikachu_with_Surf_for_minigame
 IF DEF (_YELLOW_VC)
 	bit 7, a
 ELSE
@@ -136,7 +136,7 @@ SummerBeachHouseSign4Text:
 	ld a, 1
 	ld [wDoNotWaitForButtonPressAfterDisplayingText], a
 	ld a, [wd472]
-	vc_patch MiniGameHighScorePC
+	vc_patch Bypass_need_Pikachu_with_Surf_for_high_score
 IF DEF(_YELLOW_VC)
 	bit 7, a
 ELSE

--- a/vc/pokeyellow.patch.template
+++ b/vc/pokeyellow.patch.template
@@ -25,7 +25,7 @@
 ;ReduceColorB1 = 0	;0~31 (for Green Mode)
 ;MotionBlur1 = 31	;0~31 (for Green Mode)
 ;PaletteX = c31,31,31	;X:0~15, cR,G,B (0~31)
-[SaveLimit]
+[SaveLimit@Unknown_save_limit]
 Mode = 12
 Type = 1
 Index = {hex sGameData}
@@ -36,7 +36,7 @@ Address = {hex sGameDataEnd}
 ;Address = 0x40130
 ;Fixcode = a3: 00 00 00
 
-[disable_print]
+[disable_print@Forbid_printing_Pokedex]
 Mode = 1
 Address = {hex @+1}
 Fixcode = {PATCH +1}
@@ -46,72 +46,72 @@ Fixcode = {PATCH +1}
 ;Address = 0x1551
 ;Type = 3
 
-[MiniGame]
+[MiniGame@Bypass_need_Pikachu_with_Surf_for_minigame]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[MiniGame-HighScorePC@MiniGameHighScorePC]
+[MiniGame-HighScorePC@Bypass_need_Pikachu_with_Surf_for_high_score]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[send_send_buf2]
+[send_send_buf2@Wireless_WaitLinkTransfer]
 Mode = 2
 Address = {HEX @}
 Type = 29
 
-[send_send_buf2_ret]
+[send_send_buf2_ret@Wireless_WaitLinkTransfer_ret]
 Mode = 2
 Address = {HEX @}
 Type = 30
 
-[send_byt2]
+[send_byt2@Wireless_start_exchange]
 Mode = 2
 Address = {HEX @+5}
 Type = 31
 
-[send_byt2_ret]
+[send_byt2_ret@Wireless_end_exchange]
 Mode = 2
 Address = {HEX @}
 Type = 32
 
-[send_dummy]
+[send_dummy@Wireless_start_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 33
 
-[send_dummy_end]
+[send_dummy_end@Wireless_end_send_zero_bytes]
 Mode = 2
 Address = {HEX @}
 Type = 34
 
-[FIGHT]
+[FIGHT@Wireless_net_delay_1]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[FIGHT2]
+[FIGHT2@Wireless_net_delay_2]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network10]
+[Network10@Wireless_net_delay_3]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network11]
+[Network11@Wireless_net_delay_4]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[Network424]
+[Network424@Wireless_ExchangeBytes_1]
 Mode = 2
 Address = {HEX @}
 Type = 4
 
-[Network200]
+[Network200@Wireless_ExchangeBytes_2]
 Mode = 2
 Address = {HEX @}
 Type = 4
@@ -132,52 +132,52 @@ Type = 4
 ;Address = 0x150
 ;Fixcode = 0xC9
 
-[PLAY_MUTE]
+[PLAY_MUTE@Unknown_PlayPikachuSoundClip_end]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH +1}
 
-[PLAY_HACK]
+[PLAY_HACK@Unknown_PlayPikachuPCM]
 Mode = 2
 Address = {HEX @}
 Type = 6
 
-[PLAY_NEW]
+[PLAY_NEW@Unknown_PlayPikachuSoundClip_start]
 Mode = 2
 Address = {HEX @}
 Type = 21
 
-[Network_RECHECK]
+[Network_RECHECK@Wireless_net_recheck]
 Mode = 2
 Address = {HEX @}
 Type = 7
 
-[Network_STOP]
+[Network_STOP@Wireless_net_stop]
 Mode = 2
 Address = {HEX @}
 Type = 8
 
-[Network_END]
+[Network_END@Wireless_net_end]
 Mode = 2
 Address = {HEX @}
 Type = 9
 
-[Network_RESET]
+[Network_RESET@Unknown_network_reset]
 Mode = 2
 Address = {HEX @}
 Type = 10
 
-[linkCable fake begin]
+[linkCable fake begin@Link_fake_connection_status]
 Mode = 2
 Address = {HEX @}
 Type = 16
 
-[linkCable fake end]
+[linkCable fake end@Wireless_prompt]
 Mode = 2
 Address = {HEX @}
 Type = 17  
   
-[linkCable block input]
+[linkCable block input@Wireless_TryQuickSave_block_input]
 Mode = 2
 Address = {HEX @+5}
 Type = 18
@@ -187,29 +187,29 @@ Type = 18
 ;Address = 0x5A84
 ;Type = 19
 
-[save game end]
+[save game end@Trade_save_game_end]
 Mode = 2
 Address = {HEX @}
 Type = 20
 
-[Change_MSG]
+[Change_MSG@Change_link_closed_inactivity_message]
 Mode = 1
 Address = {HEX @+1}
 Fixcode = {PATCH_ +1 20}
 
-[fight_ret]
+[fight_ret@BattleRandom_ret]
 Mode = 1
 Address = {hex @}
 Fixcode = {PATCH}
 
-[fight_ret_c]
+[fight_ret_c@Unknown_BattleRandom_ret_c]
 Mode = 2
 Address = {hex @}
 Type = 98
 
 ;Mem Write: pc32 = 0xf992d addr = 0xc634 value = 0xe
 ;Mem Write: pc32 = 0xf9e51 addr = 0xc635 value = 0x1
-[FPA 031801 Begin1]       
+[FPA 031801 Begin1@Reduce_intro_scene_flashing_0E]       
 Mode = 3                   
 Type = 0                   
 Address = {hex @}         
@@ -222,7 +222,7 @@ ConditionValueC = {dws_ 0x0e                    }
 
 ;34 6F 26 00
 ;Mem Write: pc32 = 0xf9e51 addr = 0xc635 value = 0x33   
-[FPA 031801 End1]                
+[FPA 031801 End1@Stop_reducing_intro_scene_flashing_0E]                
 Mode = 3                         
 Type = 1                         
 Address = {hex @}                
@@ -237,7 +237,7 @@ ConditionValueC = {dws_ 0x0e                     0x33                  }
 ;rsm095822 
 ;Mem Write: pc32 = 0xf9d8b addr = 0xc635 value = 0x28  
 ;30                                                                   
-[FPA 031801 Begin2]                                                                         
+[FPA 031801 Begin2@Reduce_intro_scene_flashing_0F]                                                                         
 Mode = 3                                                                                
 Type = 0                                                                                
 Address = {hex @}                                                                    
@@ -249,7 +249,7 @@ ConditionValueB = {dws_ ==                      }
 ConditionValueC = {dws_ 0x0f                    }  
 
                               
-[FPA 031801 End2]             
+[FPA 031801 End2@Stop_reducing_intro_scene_flashing_0F]             
 Mode = 3                      
 Type = 1                      
 Address = 0xF9e4b 
@@ -260,7 +260,7 @@ ConditionValueC = {dws_ 0x0f                    }
 
 ;222222aaaaaaaaaaaaaaaa: pc32 = 0xf984b addr = 0xffb3 value = 0x0               
 ;000f984bh: F0 B3 E6 0B                                        
-[FPA 031801 End3]                                                         
+[FPA 031801 End3@Stop_Reducing_intro_scene_flashing]                                                         
 Mode = 3                                                                  
 Type = 1                                                                  
 Address = {hex @}                                                         
@@ -293,7 +293,7 @@ ConditionValueC = {dws_ 0x0e                      00  0x0f                    }
 ;Mem Write: pc32 = 0x781c5 addr = 0xd086 value = 0x3      
 ;17 --13     
 ;No151 Mega Punch            
-[FPA 001 Begin]                       
+[FPA 001 Begin@Reduce_move_anim_flashing_Mega_Punch_Explosion_Self_Destruct]                       
 Mode = 3                              
 Type = 0                              
 Address = {hex @}                     
@@ -304,7 +304,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==              ==            ||  ==            ==              ==              ==              ==            ||  ==            ==              ==              ==              ==          }          
 ConditionValueC = {dws_ "M"           "E"             "G"             "A"             "P"             MEGA_PUNCH    00  "E"           "X"             "P"             "L"             MEGA_PUNCH    00  "S"           "E"             "L"             "F"             MEGA_PUNCH  }          
                                       
-[FPA 001 End]                         
+[FPA 001 End@Stop_reducing_move_anim_flashing_Mega_Punch]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}                 
@@ -316,7 +316,7 @@ ConditionValueC = {dws_ "M"           "E"             "G"             "A"       
 ;rsm103725   
 ;Mem Write: pc32 = 0x781c5 addr = 0xd086 value = 0x3  
 ;No117  Guillotine                 
-[FPA 002 Begin]                       
+[FPA 002 Begin@Reduce_move_anim_flashing_Guillotine]                       
 Mode = 3                              
 Type = 0                              
 Address = {hex @}                     
@@ -327,7 +327,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }           
 ConditionValueC = {dws_ "G"           "U"             "I"             "L"             GUILLOTINE  }           
                                       
-[FPA 002 End]                         
+[FPA 002 End@Stop_reducing_move_anim_flashing_Guillotine]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}               
@@ -340,7 +340,7 @@ ConditionValueC = {dws_ "G"           "U"             "I"             "L"       
 ;rsm142438   
 ;17 --13 
 ;No150 Mega Kick                        
-[FPA 003 Begin]                       
+[FPA 003 Begin@Reduce_move_anim_flashing_Mega_Kick]                       
 Mode = 3                              
 Type = 0                              
 Address = {hex @}                     
@@ -351,7 +351,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==              ==          }         
 ConditionValueC = {dws_ "M"           "E"             "G"             "A"             "K"             MEGA_KICK   }         
                                       
-[FPA 003 End]                         
+[FPA 003 End@Stop_reducing_move_anim_flashing_Mega_Kick]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}               
@@ -362,7 +362,7 @@ ConditionValueC = {dws_ "M"           "E"             "G"             "A"       
 
 ;rsm154217   blizzard   
 ;No131                     
-[FPA 004 Begin]                           
+[FPA 004 Begin@Reduce_move_anim_flashing_Blizzard]                           
 Mode = 3                                  
 Type = 0                                  
 Address = {hex @}                         
@@ -373,7 +373,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }                 
 ConditionValueC = {dws_ "B"           "L"             "I"             "Z"             BLIZZARD    }                 
                                           
-[FPA 004 End]                             
+[FPA 004 End@Stop_reducing_move_anim_flashing_Blizzard]                             
 Mode = 3                                  
 Type = 1                                  
 Address = {hex @}                        
@@ -386,7 +386,7 @@ ConditionValueC = {dws_ "B"           "L"             "I"             "Z"       
 
 ;rsm163638       bubblebeam 
 ;No123                    
-[FPA 005 Begin]                       
+[FPA 005 Begin@Reduce_move_anim_flashing_Bubblebeam]                       
 Mode = 3                              
 Type = 0                              
 Address = {hex @}                     
@@ -397,7 +397,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }         
 ConditionValueC = {dws_ "B"           "U"             "B"             "B"             BUBBLEBEAM  }         
                                       
-[FPA 005 End]                         
+[FPA 005 End@Stop_reducing_move_anim_flashing_Bubblebeam]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}              
@@ -409,7 +409,7 @@ ConditionValueC = {dws_ "B"           "U"             "B"             "B"       
 ;Mem Write: pc32 = 0xc2 addr = 0xcfd1 value = 0x3f
 ;Pallte Write: pc32 =00078e79 00000048 e4         
 ;No116            hyper beam                    
-[FPA 006 Begin]                            
+[FPA 006 Begin@Reduce_move_anim_flashing_Hyper_Beam]                            
 Mode = 3                                   
 Type = 0                                   
 Address = {hex @}                       
@@ -423,7 +423,7 @@ ConditionValueC = {dws_ "H"           "Y"             "P"             HYPER_BEAM
 ;rsm112921       thunderbolt   
 ;15 -- 13  
 ;No57 thunderbolt                
-[FPA 007 Begin]                                
+[FPA 007 Begin@Reduce_move_anim_flashing_Thunderbolt]                                
 Mode = 3                                       
 Type = 0                                       
 Address = {hex @}                              
@@ -434,7 +434,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }                    
 ConditionValueC = {dws_ "T"           "H"             "U"             "N"             THUNDERBOLT }                    
                                               
-[FPA 007 End]                                  
+[FPA 007 End@Stop_reducing_move_anim_flashing_Thunderbolt]                                  
 Mode = 3                                       
 Type = 1                                       
 Address = {hex @} 
@@ -445,7 +445,7 @@ ConditionValueC = {dws_ "T"           "H"             "U"             "N"       
 ;
 ;rsm130806      haze   
 ;No40 haze                   
-[FPA 008 Begin]                         
+[FPA 008 Begin@Reduce_move_anim_flashing_Haze]                         
 Mode = 3                                
 Type = 0                                
 Address = {hex @}                       
@@ -456,7 +456,7 @@ ConditionValueA =  {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBu
 ConditionValueB =  {dws_ ==            ==              ==              ==              ==          }            
 ConditionValueC =  {dws_ "H"           "A"             "Z"             "E"             HAZE        }            
                                         
-[FPA 008 End]                           
+[FPA 008 End@Stop_reducing_move_anim_flashing_Haze_Hyper_Beam]                           
 Mode = 3                                
 Type = 1                                
 Address = {hex @}                      
@@ -468,7 +468,7 @@ ConditionValueC = {dws_ "H"           "A"             "Z"             "E"       
 
 ;rsm131656       reflect  
 ;No159                  
-[FPA 009 Begin]                           
+[FPA 009 Begin@Reduce_move_anim_flashing_Reflect]                           
 Mode = 3                                  
 Type = 0                                  
 Address = {hex @}                         
@@ -479,7 +479,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }               
 ConditionValueC = {dws_ "R"           "E"             "F"             "L"             REFLECT     }               
                                           
-[FPA 009 End]                             
+[FPA 009 End@Stop_reducing_move_anim_flashing_Reflect]                             
 Mode = 3                                  
 Type = 1                                  
 Address = {hex @}                         
@@ -490,7 +490,7 @@ ConditionValueC =  {dws_ "R"           "E"             "F"             "L"      
 
 ;rsm132935       selfdestruct  
 ;No56                  
-[FPA 010 Begin]                        
+[FPA 010 Begin@Reduce_move_anim_flashing_Self_Destruct]                        
 Mode = 3                               
 Type = 0                               
 Address = {hex @}                     
@@ -501,7 +501,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }              
 ConditionValueC = {dws_ "S"           "E"             "L"             "F"             SELFDESTRUCT}              
                                         
-[FPA 010 End]                          
+[FPA 010 End@Stop_reducing_move_anim_flashing_Self_Destruct]                          
 Mode = 3                               
 Type = 1                               
 Address = {hex @}                      
@@ -512,7 +512,7 @@ ConditionValueC = {dws_ "S"           "E"             "L"             "F"       
 
 ;rsm013740       explosion  
 ;No76               
-[FPA 011 Begin]                       
+[FPA 011 Begin@Reduce_move_anim_flashing_Explosion]                       
 Mode = 3                              
 Type = 0                              
 Address = {hex @}                    
@@ -523,7 +523,7 @@ ConditionValueA = {dws_ wStringBuffer wStringBuffer+1 wStringBuffer+2 wStringBuf
 ConditionValueB = {dws_ ==            ==              ==              ==              ==          }            
 ConditionValueC = {dws_ "E"           "X"             "P"             "L"             EXPLOSION   }            
                                       
-[FPA 011 End]                         
+[FPA 011 End@Stop_reducing_move_anim_flashing_Explosion]                         
 Mode = 3                              
 Type = 1                              
 Address = {hex @}            


### PR DESCRIPTION
Please reference: [pret/pokecrystal#886](https://github.com/pret/pokecrystal/issues/886) [pret/pokecrystal#907](https://github.com/pret/pokecrystal/pull/907) pret/pokered#357

Notable differences from [pret/pokecrystal#907](https://github.com/pret/pokecrystal/pull/907) && pret/pokered#357:

*   `disable_print` => `Forbid_printing_Pokedex`
*   `FPA_031801_End3` => `Stop_Reducing_intro_scene_flashing`
*   `FPA_031801_Begin1` => `Reduce_intro_scene_flashing_0E` (Seems to be related to the thunderbolt scene)
*   `FPA_031801_Begin2` => `Reduce_intro_scene_flashing_0F` (Not entirely sure what scene 0f is.)
*   `FPA_031801_End2` => `Stop_Reducing_intro_scene_flashing_0F` (Not entirely sure what scene 0f is.)
*   `FPA_031801_End1` => `Stop_reducing_intro_scene_flashing_0E` (Seems to be related to the thunderbolt scene)
*   `PLAY_NEW` => `Unknown_PlayPikachuSoundClip_start`
*   `PLAY_MUTE` => `Unknown_PlayPikachuSoundClip_end`
*   `PLAY_HACK` => `Unknown_PlayPikachuPCM`
*   `MiniGame` => `Bypass_need_Pikachu_with_Surf_for_minigame`
*   `MiniGameHighScorePC` => `Bypass_need_Pikachu_with_Surf_for_high_score`