### PR TITLE
fixed 2 locations/comments

### DIFF
--- a/data/trainers/parties.asm
+++ b/data/trainers/parties.asm
@@ -101,6 +101,7 @@ BugCatcherData:
 ; Route 9
 	db 19, BEEDRILL, BEEDRILL, 0
 	db 20, CATERPIE, WEEDLE, VENONAT, 0
+; Viridian Forest
 	db 8, CATERPIE, METAPOD, 0
 
 LassData:
@@ -131,6 +132,7 @@ LassData:
 ; Celadon Gym
 	db 23, BELLSPROUT, WEEPINBELL, 0
 	db 23, ODDISH, GLOOM, 0
+; Viridian Forest
 	db 6, NIDORAN_F, NIDORAN_M, 0
 
 SailorData:


### PR DESCRIPTION
Last BugCatcher and last Lass are in Viridian Forest instead of Route 9 and Celadon Gym.
These are the only 2 extra trainers yellow got compared to red/blue.