### PR TITLE
Rename wdef5 to wdef4 to match memory location

### DIFF
--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -16,7 +16,7 @@ DrawFrameBlock:
 	inc a
 	ld [wFBTileCounter], a
 	ld a, $2
-	ld [wdef5], a
+	ld [wdef4], a
 	ld a, [wSubAnimTransform]
 	dec a
 	jr z, .flipHorizontalAndVertical   ; SUBANIMTYPE_HVFLIP
@@ -50,9 +50,9 @@ DrawFrameBlock:
 	ld [de], a ; store X
 	cp 88
 	jr c, .asm_78056
-	ld a, [wdef5]
+	ld a, [wdef4]
 	inc a
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_78056
 	inc hl
 	inc de
@@ -62,7 +62,7 @@ DrawFrameBlock:
 	inc de
 	ld a, [hli]
 	ld b, a
-	ld a, [wdef5]
+	ld a, [wdef4]
 	or b
 	ld [de], a ; store flags
 	inc de
@@ -84,9 +84,9 @@ DrawFrameBlock:
 	ld [de], a ; store X
 	cp 88
 	jr c, .asm_78087
-	ld a, [wdef5]
+	ld a, [wdef4]
 	inc a
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_78087
 	inc hl
 	inc de
@@ -107,7 +107,7 @@ DrawFrameBlock:
 	jr z, .storeFlags1
 	ld b, 0
 .storeFlags1
-	ld a, [wdef5]
+	ld a, [wdef4]
 	or b
 	ld [de], a
 	inc de
@@ -127,9 +127,9 @@ DrawFrameBlock:
 	ld [de], a ; store X
 	cp 88
 	jr c, .asm_780c8
-	ld a, [wdef5]
+	ld a, [wdef4]
 	inc a
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_780c8
 	inc hl
 	inc de
@@ -147,7 +147,7 @@ DrawFrameBlock:
 	res 5, a
 .storeFlags2
 	ld b, a
-	ld a, [wdef5]
+	ld a, [wdef4]
 	or b
 	ld [de], a
 	inc de
@@ -1184,14 +1184,14 @@ _AnimationWaterDroplets:
 	ld hl, wShadowOAM
 .loop
 	ld a, $1
-	ld [wdef5], a
+	ld [wdef4], a
 	ld a, [wBaseCoordY]
 	ld [hli], a ; Y
 	cp 40
 	jr c, .asm_792d7
-	ld a, [wdef5]
+	ld a, [wdef4]
 	inc a
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_792d7
 	ld a, [wBaseCoordX]
 	add 27
@@ -1199,14 +1199,14 @@ _AnimationWaterDroplets:
 	ld [hli], a ; X
 	cp 88
 	jr c, .asm_792ee
-	ld a, [wdef5]
+	ld a, [wdef4]
 	add $2
 	and $3
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_792ee
 	ld a, [wDropletTile]
 	ld [hli], a ; tile
-	ld a, [wdef5]
+	ld a, [wdef4]
 	ld [hli], a ; attribute
 	ld a, [wBaseCoordX]
 	cp 144
@@ -1351,28 +1351,28 @@ BattleAnimWriteOAMEntry:
 ; tile = d
 ; attributes = variable (depending on coords)
 	ld a, $1
-	ld [wdef5], a
+	ld [wdef4], a
 	ld a, e
 	add 8
 	ld e, a
 	ld [hli], a
 	cp 40
 	jr c, .asm_793d8
-	ld a, [wdef5]
+	ld a, [wdef4]
 	inc a
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_793d8
 	ld a, [wBaseCoordX]
 	ld [hli], a
 	cp 88
 	jr c, .asm_793e8
-	ld a, [wdef5]
+	ld a, [wdef4]
 	add $2
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_793e8
 	ld a, d
 	ld [hli], a
-	ld a, [wdef5]
+	ld a, [wdef4]
 	ld [hli], a
 	ret
 
@@ -1578,7 +1578,7 @@ AnimationSpiralBallsInward:
 	cp $ff
 	jr z, .done
 	ld a, $2
-	ld [wdef5], a
+	ld [wdef4], a
 	ld a, [wSpiralBallsBaseY]
 	add [hl]
 	ld [de], a ; Y
@@ -1590,7 +1590,7 @@ AnimationSpiralBallsInward:
 	cp 88
 	jr c, .asm_79524
 	ld a, $3
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_79524
 	inc hl
 	inc de
@@ -1598,7 +1598,7 @@ AnimationSpiralBallsInward:
 	ld a, [de]
 	and $f0
 	ld b, a
-	ld a, [wdef5]
+	ld a, [wdef4]
 	or b
 	ld [de], a
 	inc de
@@ -2534,7 +2534,7 @@ FallingObjects_UpdateOAMEntry:
 	ld hl, wShadowOAM
 	add hl, de
 	ld a, $1
-	ld [wdef5], a
+	ld [wdef4], a
 	ld a, [hl]
 	inc a
 	inc a
@@ -2545,9 +2545,9 @@ FallingObjects_UpdateOAMEntry:
 	ld [hli], a ; Y
 	cp 40
 	jr c, .asm_79e51
-	ld a, [wdef5]
+	ld a, [wdef4]
 	inc a
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_79e51
 	ld a, [wFallingObjectMovementByte]
 	ld b, a
@@ -2567,10 +2567,10 @@ FallingObjects_UpdateOAMEntry:
 	ld [hli], a ; X
 	cp 88
 	jr c, .asm_79e75
-	ld a, [wdef5]
+	ld a, [wdef4]
 	add $2
 	and $3
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_79e75
 	inc hl
 	xor a ; no horizontal flip
@@ -2583,16 +2583,16 @@ FallingObjects_UpdateOAMEntry:
 	ld [hli], a ; X
 	cp 88
 	jr c, .asm_79e5c
-	ld a, [wdef5]
+	ld a, [wdef4]
 	add $2
 	and $3
-	ld [wdef5], a
+	ld [wdef4], a
 .asm_79e5c
 	inc hl
 	ld a, (1 << OAM_X_FLIP)
 .next2
 	ld b, a
-	ld a, [wdef5]
+	ld a, [wdef4]
 	or b
 	ld [hl], a ; attribute
 	ret

--- a/engine/battle/draw_hud_pokeball_gfx.asm
+++ b/engine/battle/draw_hud_pokeball_gfx.asm
@@ -28,7 +28,7 @@ SetupOwnPartyPokeballs:
 	ld a, 8
 	ld [wHUDPokeballGfxOffsetX], a
 	xor a
-	ld [wdef5], a
+	ld [wdef4], a
 	ld hl, wShadowOAM
 	jp WritePokeballOAMData
 
@@ -44,7 +44,7 @@ SetupEnemyPartyPokeballs:
 	ld a, -8
 	ld [wHUDPokeballGfxOffsetX], a
 	ld a, $1
-	ld [wdef5], a
+	ld [wdef4], a
 	ld hl, wShadowOAMSprite06
 	jp WritePokeballOAMData
 
@@ -108,7 +108,7 @@ WritePokeballOAMData:
 	ld [hli], a
 	ld a, [de]
 	ld [hli], a
-	ld a, [wdef5]
+	ld a, [wdef4]
 	ld [hli], a
 	ld a, [wBaseCoordX]
 	ld b, a
@@ -179,7 +179,7 @@ SetupPlayerAndEnemyPokeballs:
 	ld a, 8
 	ld [wHUDPokeballGfxOffsetX], a
 	xor a
-	ld [wdef5], a
+	ld [wdef4], a
 	ld hl, wShadowOAM
 	call WritePokeballOAMData
 	ld hl, wEnemyMons
@@ -190,7 +190,7 @@ SetupPlayerAndEnemyPokeballs:
 	ld [hli], a
 	ld [hl], $68
 	ld a, $1
-	ld [wdef5], a
+	ld [wdef4], a
 	ld hl, wShadowOAMSprite06
 	jp WritePokeballOAMData
 

--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2590,7 +2590,7 @@ wGBCPal:: ds PALETTE_SIZE
 wLastBGP:: db
 wLastOBP0:: db
 wLastOBP1:: db
-wdef5:: db
+wdef4:: db
 wBGPPalsBuffer:: ds NUM_ACTIVE_PALS * PALETTE_SIZE
 
 


### PR DESCRIPTION
I couldn't find this variable in pokered either so I'm guessing that it's just a misstake. Going back in time in Githubs blame view makes me think that there was a number of variables that was off by one next to this one since before, but they have all been corrected by now.

The following diff would need to be applied to the symbols file as well:

```diff
@@ -23219,7 +23219,7 @@
 00:def1 wLastBGP
 00:def2 wLastOBP0
 00:def3 wLastOBP1
-00:def4 wdef5
+00:def4 wdef4
 00:def5 wBGPPalsBuffer
 00:dfff wStack
 00:ff80 hDMARoutine
```

I've verified that the sha1 sums matches the newly built files ✅ 