### PR TITLE
Remove unused pikacry macro

### DIFF
--- a/constants/pikachu_emotion_constants.asm
+++ b/constants/pikachu_emotion_constants.asm
@@ -128,10 +128,6 @@ MACRO ldpikacry
 	ld \1, (\2_id - PikachuCriesPointerTable) / 3
 ENDM
 
-MACRO pikacry
-	ldpikacry a, \1
-ENDM
-
 
 	const_def
 	const pikapic_nop_command


### PR DESCRIPTION
This isn't used anywhere

-----

Another potential approach would be to change the macro to load into `e` instead, since it's the only register that `ldpikacry` is used with. Or potentially `ldpikacry` could be changed to always load to `e`. Not really sure what would be most nice...