### PR TITLE
Make wCurrentBoxNum a byte isntead of word

### DIFF
--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -2150,7 +2150,9 @@ wBoxItems:: ds PC_ITEM_CAPACITY * 2 + 1
 
 ; bits 0-6: box number
 ; bit 7: whether the player has changed boxes before
-wCurrentBoxNum:: dw
+wCurrentBoxNum:: db
+
+	ds 1
 
 ; number of HOF teams
 wNumHoFTeams:: db


### PR DESCRIPTION
As far as I can tell, it's only ever accessed as a byte, and the byte after it is simply unused...

(`make` still produces identical ROMs)