### PR TITLE
Add sound bits documentation for wOptions

### DIFF
--- a/ram/wram.asm
+++ b/ram/wram.asm
@@ -1929,7 +1929,12 @@ wRivalName:: ds NAME_LENGTH
 ; bit 6 = battle style
 ; 0: Shift
 ; 1: Set
-; bits 0-3 = text speed (number of frames to delay after printing a letter)
+; bits 5-4 = sound
+;	00: Mono
+;	01: Earphone1
+;	10: Earphone2
+;	11: Earphone3
+; bits 2-0 = text speed (number of frames to delay after printing a letter)
 ; 1: Fast
 ; 3: Medium
 ; 5: Slow


### PR DESCRIPTION
I'm not sure about how to best express bit ranges but I tried to be consistent here since the previous description of text speed ("bits 0-3") lead me to believe that it took up 4 bits instead of 3. I'm happy to change all of them to whatever format we want...