### PR TITLE
Fix comments around battle evolution code

### DIFF
--- a/engine/pokemon/evos_moves.asm
+++ b/engine/pokemon/evos_moves.asm
@@ -9,7 +9,7 @@ TryEvolvingMon:
 	call Evolution_FlagAction
 
 ; this is only called after battle
-; it is supposed to do level up evolutions, though there is a bug that allows item evolutions to occur
+; it does level up evolutions, though there was a bug in red/blue that allows item evolutions to occur which is patched here
 EvolutionAfterBattle:
 	ldh a, [hTileAnimations]
 	push af


### PR DESCRIPTION
the bug that allows item evolutions to happen after battles is patched here in Yellow where it isn't in Red/Blue. Updated a comment to reflect this.