### PR TITLE
Removed the trade evolutions in favour of level evo's, boosted Pikach…

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,41 @@
+# Changelog
+
+## [0.0.1] - 2024-11-17
+### Initial Build
+#### Gameplay Changes
+- Removed the requirement of trade evolutions for:
+  - Alakazam: Evolves at level 36.
+  - Golem: Evolves at level 40.
+  - Machamp: Evolves at level 38.
+  - Gengar: Evolves at level 36.
+- Since Pikachu can't evolve, it now has Raichu's base stats.
+
+#### Bug Fixes
+- **Generation 1 Fixes**:
+  - Fixed a bug where 100% accuracy moves had a small chance to miss.
+  - Fixed a bug where 100% critical-hit moves had a small chance to fail to crit.
+  - `Focus Energy` now quarters the crit chance instead of quadrupling it.
+  - Fixed a bug where `Substitute` could KO the user (it now leaves the user with at least 1 HP).
+  - Fixed a bug where move effectiveness was incorrectly displayed for dual-type Pokémon.
+  - Fixed a bug where draining moves could hit even when a substitute was set up, including:
+    - `Leech Life`
+    - `Mega Drain`
+    - `Dream Eater`
+  - Fixed a bug where PP full restore didn't account for PP UPs when used.
+  - Fixed a bug where `Struggle` didn't account for PP UP.
+  - Fixed a bug where the `wavy screen` animation for `Psychic`, `Psywave`, and `Night Shade` didn't wiggle the top three lines of the screen.
+  - Fixed a bug where invulnerability status was not cleared when a second-stage move failed due to confusion or paralysis.
+  - Fixed a bug where healing moves would fail if the user's max HP was 255 or 511 higher than their current HP.
+  - Fixed an underflow issue with switch-out messages.
+  - Fixed a bug preventing Pokémon from attacking after curing `freeze`.
+  - Fixed an issue where some trainers would always switch out Pokémon on low health rather than 25% of the time.
+  - Fixed Blaine's AI where he would spam super potions.
+  - Fixed a bug where all captured Pokémon with the transformed flag set were marked as `DITTO`.
+  - Fixed a bug where Pokémon would be registered as "seen" in the Pokédex when entering a ghost battle.
+  - Fixed a bug where stat boosts were removed when using stat-curing items.
+  - Fixed an issue where the AI health bar would not correctly update after healing.
+
+#### Notes
+This release focuses on creating a clean baseline with foundational fixes and adjustments. Further bug fixes and improvements will follow in upcoming versions.
+
+**MD5SUM**: `a045fe377f83aff15feaa53d75d48f46`

--- a/data/pokemon/base_stats/pikachu.asm
+++ b/data/pokemon/base_stats/pikachu.asm
@@ -1,6 +1,6 @@
 	db DEX_PIKACHU ; pokedex id
 
-	db  35,  55,  30,  90,  50
+	db  60,  90,  55,  100,  90
 	;   hp  atk  def  spd  spc
 
 	db ELECTRIC, ELECTRIC ; type

--- a/data/pokemon/evos_moves.asm
+++ b/data/pokemon/evos_moves.asm
@@ -628,7 +628,7 @@ SlowpokeEvosMoves:
 
 KadabraEvosMoves:
 ; Evolutions
-	db EVOLVE_TRADE, 1, ALAKAZAM
+	db EVOLVE_LEVEL, 36, ALAKAZAM
 	db 0
 ; Learnset
 	db 16, CONFUSION
@@ -641,7 +641,7 @@ KadabraEvosMoves:
 
 GravelerEvosMoves:
 ; Evolutions
-	db EVOLVE_TRADE, 1, GOLEM
+	db EVOLVE_LEVEL, 40, GOLEM
 	db 0
 ; Learnset
 	db 11, DEFENSE_CURL
@@ -667,7 +667,7 @@ ChanseyEvosMoves:
 
 MachokeEvosMoves:
 ; Evolutions
-	db EVOLVE_TRADE, 1, MACHAMP
+	db EVOLVE_LEVEL, 38, MACHAMP
 	db 0
 ; Learnset
 	db 20, LOW_KICK
@@ -1720,7 +1720,7 @@ MissingNo92EvosMoves:
 
 HaunterEvosMoves:
 ; Evolutions
-	db EVOLVE_TRADE, 1, GENGAR
+	db EVOLVE_LEVEL, 36, GENGAR
 	db 0
 ; Learnset
 	db 29, HYPNOSIS

--- a/engine/battle/animations.asm
+++ b/engine/battle/animations.asm
@@ -1969,6 +1969,8 @@ AnimationWavyScreen:
 	ld c, $ff
 	ld hl, WavyScreenLineOffsets
 .loop
+	ld a, [hl]
+	ldh [hSCX], a 
 	push hl
 .innerLoop
 	call WavyScreen_SetSCX
@@ -1985,6 +1987,7 @@ AnimationWavyScreen:
 	dec c
 	jr nz, .loop
 	xor a
+	ldh [hSCX], a
 	ldh [hWY], a
 	call SaveScreenTilesToBuffer2
 	call ClearScreen

--- a/engine/battle/common_text.asm
+++ b/engine/battle/common_text.asm
@@ -200,6 +200,7 @@ PlayerMon2Text:
 	ld b, [hl]
 	ld a, [de]
 	sbc b
+	jr c, .gainedHP ; If we underflow, print default text
 	ldh [hMultiplicand + 1], a
 	ld a, 25
 	ldh [hMultiplier], a
@@ -233,6 +234,11 @@ PlayerMon2Text:
 	cp 70
 	ret c
 	ld hl, GoodText ; HP went down 70% or more
+	ret
+.gainedHP
+	pop bc
+	pop de
+	ld hl, EnoughText ; default text
 	ret
 
 EnoughText:

--- a/engine/battle/effects.asm
+++ b/engine/battle/effects.asm
@@ -327,7 +327,7 @@ FreezeBurnParalyzeEffect:
 	ld hl, BurnedText
 	jp PrintText
 .freeze2
-; hyper beam bits aren't reseted for opponent's side
+	call ClearHyperBeam
 	ld a, 1 << FRZ
 	ld [wBattleMonStatus], a
 	ld a, SHAKE_SCREEN_ANIM

--- a/engine/battle/move_effects/heal.asm
+++ b/engine/battle/move_effects/heal.asm
@@ -11,13 +11,14 @@ HealEffect_:
 .healEffect
 	ld b, a
 	ld a, [de]
-	cp [hl] ; most significant bytes comparison is ignored
-	        ; causes the move to miss if max HP is 255 or 511 points higher than the current HP
+	cp [hl] 
 	inc de
 	inc hl
+	jr nz, .passed
 	ld a, [de]
 	sbc [hl]
 	jp z, .failed ; no effect if user's HP is already at its maximum
+.passed
 	ld a, b
 	cp REST
 	jr nz, .healHP

--- a/engine/battle/move_effects/substitute.asm
+++ b/engine/battle/move_effects/substitute.asm
@@ -55,6 +55,16 @@ SubstituteEffect_:
 	call Bankswitch ; jump to routine depending on animation setting
 	ld hl, SubstituteText
 	call PrintText
+.checkRemainingHP
+	ld a, [wEnemyMonHP+1]
+	and a 
+	jr nz, .done ; if there is remainig HP we're done 
+	ld a, [wEnemyMonHP] ; Check HP high byte
+	and a 
+	jr nz, .done 
+	ld hl, wEnemyMonHP+1
+	set 0, [hl] ; set HP to 1
+.done
 	jpfar DrawHUDsAndHPBars
 .alreadyHasSubstitute
 	ld hl, HasSubstituteText

--- a/engine/battle/trainer_ai.asm
+++ b/engine/battle/trainer_ai.asm
@@ -351,10 +351,8 @@ CooltrainerMAI:
 	jp AIUseXAttack
 
 CooltrainerFAI:
-	; The intended 25% chance to consider switching will not apply.
-	; Uncomment the line below to fix this.
 	cp 25 percent + 1
-	; ret nc
+	ret nc
 	ld a, 10
 	call AICheckIfHPBelowFraction
 	jp c, AIUseHyperPotion
@@ -558,6 +556,9 @@ AIPrintItemUseAndUpdateHPBar:
 	xor a
 	ld [wHPBarType], a
 	predef UpdateHPBar2
+	push af
+	farcall DrawEnemyHUDAndHPBar
+	pop af 
 	jp DecrementAICount
 
 AISwitchIfEnoughMons:
@@ -641,7 +642,10 @@ AICureStatus:
 	ld [hl], a ; clear status in enemy team roster
 	ld [wEnemyMonStatus], a ; clear status of active enemy
 	ld hl, wEnemyBattleStatus3
-	res BADLY_POISONED, [hl]
+	res 0, [hl]
+	push af 
+	farcall DrawEnemyHUDAndHPBar
+	pop af
 	ret
 
 AIUseXAccuracy: ; unused

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -482,14 +482,9 @@ ItemUseBall:
 
 	push hl
 
-; If the Pokémon is transformed, the Pokémon is assumed to be a Ditto.
-; This is a bug because a wild Pokémon could have used Transform via
-; Mirror Move even though the only wild Pokémon that knows Transform is Ditto.
 	ld hl, wEnemyBattleStatus3
 	bit TRANSFORMED, [hl]
 	jr z, .notTransformed
-	ld a, DITTO
-	ld [wEnemyMonSpecies2], a
 	jr .skip6
 
 .notTransformed
@@ -1008,7 +1003,10 @@ ItemUseMedicine:
 	ld de, wBattleMonStats
 	ld bc, NUM_STATS * 2
 	call CopyData ; copy party stats to in-battle stat data
-	predef DoubleOrHalveSelectedStats
+	xor a 
+	ld [wCalculateWhoseStats], a 
+	callfar CalculateModifiedStats
+	callfar ApplyBadgeStatBoosts
 	jp .doneHealing
 
 .healHP
@@ -2321,10 +2319,7 @@ ItemUsePPRestore:
 
 .fullyRestorePP
 	ld a, [hl] ; move PP
-; Note that this code has a bug. It doesn't mask out the upper two bits, which
-; are used to count how many PP Ups have been used on the move. So, Max Ethers
-; and Max Elixirs will not be detected as having no effect on a move with full
-; PP if the move has had any PP Ups used on it.
+	and %00111111 ; lower 6 bits store current PP
 	cp b ; does current PP equal max PP?
 	ret z
 	jr .storeNewAmount


### PR DESCRIPTION
 - Removed the trade evolutions in favour of level evo's
 - Boosted Pikachus base stats to match Raichu since it cannot evolve and should make it more viable in the late game (though perhaps a little OP early game) 
 - various bug fixes from gen 1