### PR TITLE
Rename `.asm_39c46` to `.loopSkipTrainer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.sn*
 *.sa*
 *.sg1
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,3 @@
 *.sn*
 *.sa*
 *.sg1
-.DS_Store

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -116,7 +116,6 @@ ReadTrainer:
 	ld [hl], a
 	jr .writeAdditionalMoveDataLoop
 .loopSkipTrainer
-; skip current trainer entry
 	ld a, [hli]
 	and a
 	jr nz, .loopSkipTrainer

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -118,7 +118,7 @@ ReadTrainer:
 .loopSkipTrainer
 ; skip current trainer entry
 	ld a, [hli]
-	and a
+	and a ; trainer entry terminator is 0, so putting NO_MOVE in SpecialTrainerMoves causes issues
 	jr nz, .loopSkipTrainer
 	jr .loopAdditionalMoveData
 .FinishUp

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -89,11 +89,11 @@ ReadTrainer:
 	ld a, [hli]
 	cp $ff
 	jr z, .FinishUp
-	cp b
-	jr nz, .asm_39c46
+	cp b ; is it the correct Trainer Class?
+	jr nz, .loopSkipTrainer
 	ld a, [hli]
-	cp c
-	jr nz, .asm_39c46
+	cp c ; is it the correct Trainer No?
+	jr nz, .loopSkipTrainer
 	ld d, h
 	ld e, l
 .writeAdditionalMoveDataLoop
@@ -115,10 +115,11 @@ ReadTrainer:
 	inc de
 	ld [hl], a
 	jr .writeAdditionalMoveDataLoop
-.asm_39c46
+.loopSkipTrainer
+; skip current trainer entry
 	ld a, [hli]
 	and a
-	jr nz, .asm_39c46
+	jr nz, .loopSkipTrainer
 	jr .loopAdditionalMoveData
 .FinishUp
 ; clear wAmountMoneyWon addresses

--- a/engine/battle/read_trainer_party.asm
+++ b/engine/battle/read_trainer_party.asm
@@ -89,10 +89,10 @@ ReadTrainer:
 	ld a, [hli]
 	cp $ff
 	jr z, .FinishUp
-	cp b ; is it the correct Trainer Class?
+	cp b
 	jr nz, .loopSkipTrainer
 	ld a, [hli]
-	cp c ; is it the correct Trainer No?
+	cp c
 	jr nz, .loopSkipTrainer
 	ld d, h
 	ld e, l
@@ -118,7 +118,7 @@ ReadTrainer:
 .loopSkipTrainer
 ; skip current trainer entry
 	ld a, [hli]
-	and a ; trainer entry terminator is 0, so putting NO_MOVE in SpecialTrainerMoves causes issues
+	and a
 	jr nz, .loopSkipTrainer
 	jr .loopAdditionalMoveData
 .FinishUp


### PR DESCRIPTION
Name loop to skip a trainer entry when allocating moves from SpecialTrainerMoves