### PR TITLE
Use "command -v" instead of "which"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ pokeyellow_vc_obj    := $(rom_obj:.o=_vc.o)
 
 ### Build tools
 
-ifeq (,$(shell which sha1sum))
+ifeq (,$(shell command -v sha1sum 2>/dev/null))
 SHA1 := shasum
 else
 SHA1 := sha1sum


### PR DESCRIPTION
The "which" command has been deprecated in debianutils, and while other
distributions still ship it, "command -v" is in POSIX and implemented
without external packages.
