### PR TITLE
Name Functions .asm_41d6d and .asm_41d73

### DIFF
--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -160,7 +160,7 @@ OptionsMenu_BattleStyle:
 	jr .done
 .buttonPressed
 	ld a, [wOptions]
-	and 1 << BIT_BATTLE_SHIFT
+	xor 1 << BIT_BATTLE_SHIFT
 	ld [wOptions], a
 .done
 	ld bc, $0

--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -156,13 +156,13 @@ OptionsMenu_BattleStyle:
 	and PAD_LEFT | PAD_RIGHT
 	jr nz, .buttonPressed
 	ld a, [wOptions]
-	and $40 ; mask other bits
-	jr .noButtonPressed
+	and 1 << BIT_BATTLE_SHIFT
+	jr .done
 .buttonPressed
 	ld a, [wOptions]
-	xor $40
+	and 1 << BIT_BATTLE_SHIFT
 	ld [wOptions], a
-.noButtonPressed
+.done
 	ld bc, $0
 	sla a
 	sla a

--- a/engine/menus/options.asm
+++ b/engine/menus/options.asm
@@ -154,15 +154,15 @@ AnimationOffText:
 OptionsMenu_BattleStyle:
 	ldh a, [hJoy5]
 	and PAD_LEFT | PAD_RIGHT
-	jr nz, .asm_41d6b
+	jr nz, .buttonPressed
 	ld a, [wOptions]
 	and $40 ; mask other bits
-	jr .asm_41d73
-.asm_41d6b
+	jr .noButtonPressed
+.buttonPressed
 	ld a, [wOptions]
 	xor $40
 	ld [wOptions], a
-.asm_41d73
+.noButtonPressed
 	ld bc, $0
 	sla a
 	sla a


### PR DESCRIPTION
Added the names .buttonPressed and .noButtonPressed to the previously unnamed .asm_41d73 and .asm_41d6d.

This function is only present in yellow, and not red/blue, so submitting PR directly to this repo... Thoth-33 came up with the idea based on help with my current game/repo