### PR TITLE
Replace hardcoded offset with addresses diff when saving pikachu happiness in SaveSAVtoSRAM2

### DIFF
--- a/engine/menus/save.asm
+++ b/engine/menus/save.asm
@@ -251,7 +251,7 @@ SaveSAVtoSRAM2:
 	ld bc, wPokedexSeenEnd - wPokedexOwned
 	call CopyData
 	ld hl, wPikachuHappiness
-	ld de, sMainData + $179
+	ld de, sMainData + (wPikachuHappiness - wMainDataStart)
 	ld a, [hli]
 	ld [de], a
 	inc de


### PR DESCRIPTION
This comes from a bug report @RainbowMetalPigeon got on ExtremeYellow. While investigating the root cause we discovered that hardcoded value. It's the offset to get Pikachu's happiness inside sMainData.